### PR TITLE
Abstract out file storage so it can be handled by the embedding app

### DIFF
--- a/src/packages/excalidraw/components/ExcalidrawApp.tsx
+++ b/src/packages/excalidraw/components/ExcalidrawApp.tsx
@@ -547,6 +547,7 @@ const ExcalidrawWrapper = (props: ExcalidrawAppProps) => {
           collabServerUrl={props.collabServerUrl}
           collabDetails={props.collabDetails}
           excalidrawAPI={excalidrawAPI}
+          roomFileInterface={props.roomFileInterface}
         />
       )}
       {errorMessage && (

--- a/src/packages/excalidraw/index.tsx
+++ b/src/packages/excalidraw/index.tsx
@@ -33,6 +33,8 @@ export {
   bumpVersion,
 } from "../../element/mutateElement";
 
+export { compressData, decompressData } from "../../data/encode";
+
 export {
   parseLibraryTokensFromUrl,
   useHandleLibrary,

--- a/src/types.ts
+++ b/src/types.ts
@@ -351,6 +351,7 @@ export interface ExcalidrawAppProps {
   collabDetails?: { roomId: string; roomKey: string };
   excalidraw: ExcalidrawProps;
   getCollabAPI?: Function;
+  roomFileInterface?: RoomFileInterface;
 }
 
 export type SceneData = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,27 @@ export type LibraryItemsSource =
   | Promise<LibraryItems_anyVersion | Blob>;
 // -----------------------------------------------------------------------------
 
+// Similar to FileManager constructor param, but with roomId/roomKey
+export interface RoomFileInterface {
+  getFiles(
+    roomId: string,
+    roomKey: string,
+    fileIds: FileId[],
+  ): Promise<{
+    loadedFiles: BinaryFileData[];
+    erroredFiles: Map<FileId, true>;
+  } | null>;
+
+  saveFiles: (
+    roomId: string,
+    roomKey: string,
+    data: { addedFiles: Map<FileId, BinaryFileData> },
+  ) => Promise<{
+    savedFiles: Map<FileId, true>;
+    erroredFiles: Map<FileId, true>;
+  } | null>;
+}
+
 // NOTE ready/readyPromise props are optional for host apps' sake (our own
 // implem guarantees existence)
 export type ExcalidrawAPIRefValue =
@@ -321,6 +342,7 @@ export interface CollabProps {
   collabDetails?: { roomId: string; roomKey: string };
   excalidrawAPI: ExcalidrawImperativeAPI;
   modalIsShown?: boolean;
+  roomFileInterface?: RoomFileInterface;
   useTestEnv?: boolean;
 }
 


### PR DESCRIPTION
Hopefully a step toward https://github.com/jitsi/jitsi-meet/issues/13776

Example RoomFileInterface might look like this: (Assuming localhost:9000 is running a simple writable file server (I tested with MinIO). **note: this example doesn't handle encryption**)
```js
const FILES_URL = "http://localhost:9000/exc-test";

function fetchWithError(...args) {
    return fetch(...args)
        .then(res => {
            if(res.status < 200 || res.status >= 300) {
                return res.text()
                    .then(text => {
                        throw new Error(text);
                    });
            }
            return res;
        });
}

const roomFileInterface = {
    async saveFiles(roomId, roomKey, data) {
        const erroredFiles = new Map();
        const savedFiles = new Map();

        await Promise.all(Array.from(data.addedFiles, async ([id, data]) => {
            try {
                const content = await fetchWithError(data.dataURL).then(res => res.blob());
                await fetchWithError(
                    FILES_URL + "/" + encodeURIComponent(roomId) + "/" + encodeURIComponent(id),
                    {method: "PUT", headers: {"Content-Type": data.mimeType}, body: content},
                );
                savedFiles.set(id, true);
            } catch(ex) {
                console.error(ex);
                erroredFiles.set(id, true);
            }
        }));

        console.log(erroredFiles, savedFiles);

        return {erroredFiles, savedFiles};
    },
    async getFiles(roomId, roomKey, fileIds) {
        const erroredFiles = new Map();
        const loadedFiles = [];

        await Promise.all(fileIds.map(async (id) => {
            try {
                const res = await fetchWithError(
                    FILES_URL + "/" + encodeURIComponent(roomId) + "/" + encodeURIComponent(id),
                );
                loadedFiles.push({
                    mimeType: res.headers.get("Content-Type"),
                    id,
                    created: new Date(res.headers.get("Date")).getTime(),
                    dataURL: await res.blob()
                        .then(blob => {
                            // I would hope there's a better way to do this but I couldn't find one
                            return new Promise((resolve, reject) => {
                                const reader = new FileReader();
                                reader.addEventListener("load", () => {
                                    resolve(reader.result);
                                });
                                reader.addEventListener("error", reject);
                                reader.readAsDataURL(blob);
                            });
                        }),
                });
            } catch(ex) {
                console.error(ex);
                erroredFiles.set(id, true);
            }
        }));

        return {erroredFiles, loadedFiles};
    },
};
```