### PR TITLE
fix: optimized SVG handling with a scalable approach

### DIFF
--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -1,107 +1,235 @@
+import clsx from "clsx";
 import { KEYS } from "./keys";
+
+type Opts = {
+  width?: number;
+  height?: number;
+  mirror?: true;
+} & React.SVGProps<SVGSVGElement>;
+
+export const createIcon = (
+  d: string | React.ReactNode,
+  opts: number | Opts = 512,
+) => {
+  const {
+    width = 512,
+    height = width,
+    mirror,
+    style,
+    ...rest
+  } = typeof opts === "number" ? ({ width: opts } as Opts) : opts;
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      role="img"
+      viewBox={`0 0 ${width} ${height}`}
+      className={clsx({ "rtl-mirror": mirror })}
+      style={style}
+      {...rest}
+    >
+      {typeof d === "string" ? <path fill="currentColor" d={d} /> : d}
+    </svg>
+  );
+};
+
+const tablerIconProps: Opts = {
+  width: 24,
+  height: 24,
+  fill: "none",
+  strokeWidth: 2,
+  stroke: "currentColor",
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+} as const;
+
+const modifiedTablerIconProps: Opts = {
+  width: 20,
+  height: 20,
+  fill: "none",
+  stroke: "currentColor",
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+} as const;
+
+// -----------------------------------------------------------------------------
+
+// custom
+export const SelectionIcon = createIcon(
+  <g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path
+      d="M6 6l4.153 11.793a0.365 .365 0 0 0 .331 .207a0.366 .366 0 0 0 .332 -.207l2.184 -4.793l4.787 -1.994a0.355 .355 0 0 0 .213 -.323a0.355 .355 0 0 0 -.213 -.323l-11.787 -4.36z"
+      fill="none"
+    />
+    <path d="M13.5 13.5l4.5 4.5" fill="none" />
+  </g>,
+  { fill: "none", width: 22, height: 22, strokeWidth: 1.25 },
+);
+
+// tabler-icons: square
+export const RectangleIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <rect x="4" y="4" width="16" height="16" rx="2" fill="none"></rect>
+  </g>,
+  tablerIconProps,
+);
+
+// tabler-icons: square-rotated
+export const DiamondIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path
+      d="M10.5 20.4l-6.9 -6.9c-.781 -.781 -.781 -2.219 0 -3l6.9 -6.9c.781 -.781 2.219 -.781 3 0l6.9 6.9c.781 .781 .781 2.219 0 3l-6.9 6.9c-.781 .781 -2.219 .781 -3 0z"
+      fill="none"
+    />
+  </g>,
+
+  tablerIconProps,
+);
+
+// tabler-icons: circle
+export const EllipseIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <circle cx="12" cy="12" r="9" fill="none" />
+  </g>,
+
+  tablerIconProps,
+);
+
+// tabler-icons: arrow-narrow-right
+export const ArrowIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+    <line x1="15" y1="16" x2="19" y2="12" />
+    <line x1="15" y1="8" x2="19" y2="12" />
+  </g>,
+  tablerIconProps,
+);
+
+// custom?
+export const LineIcon = createIcon(
+  <path d="M4.167 10h11.666" strokeWidth="1.5" />,
+  modifiedTablerIconProps,
+);
+
+export const PenModeIcon = createIcon(
+  <g strokeWidth="1.25">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path
+      d="M20 17v-12c0 -1.121 -.879 -2 -2 -2s-2 .879 -2 2v12l2 2l2 -2z"
+      fill="none"
+    />
+    <path d="M16 7h4" fill="none" />
+    <path d="M18 19h-13a2 2 0 1 1 0 -4h4a2 2 0 1 0 0 -4h-3" fill="none" />
+  </g>,
+  tablerIconProps,
+);
+
+// modified tabler-icons: pencil
+export const FreedrawIcon = createIcon(
+  <g strokeWidth="1.25">
+    <path
+      fill="none"
+      clipRule="evenodd"
+      d="m7.643 15.69 7.774-7.773a2.357 2.357 0 1 0-3.334-3.334L4.31 12.357a3.333 3.333 0 0 0-.977 2.357v1.953h1.953c.884 0 1.732-.352 2.357-.977Z"
+    />
+    <path d="m11.25 5.417 3.333 3.333" fill="none" />
+  </g>,
+
+  modifiedTablerIconProps,
+);
+
+// tabler-icons: typography
+export const TextIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <line x1="4" y1="20" x2="7" y2="20" />
+    <line x1="14" y1="20" x2="21" y2="20" />
+    <line x1="6.9" y1="15" x2="13.8" y2="15" />
+    <line x1="10.2" y1="6.3" x2="16" y2="20" />
+    <polyline points="5 20 11 4 13 4 20 20" fill="none"></polyline>
+  </g>,
+  tablerIconProps,
+);
+
+// modified tabler-icons: photo
+export const ImageIcon = createIcon(
+  <g strokeWidth="1.25">
+    <path d="M12.5 6.667h.01" fill="none" />
+    <path
+      d="M4.91 2.625h10.18a2.284 2.284 0 0 1 2.285 2.284v10.182a2.284 2.284 0 0 1-2.284 2.284H4.909a2.284 2.284 0 0 1-2.284-2.284V4.909a2.284 2.284 0 0 1 2.284-2.284Z"
+      fill="none"
+    />
+    <path
+      d="m3.333 12.5 3.334-3.333c.773-.745 1.726-.745 2.5 0l4.166 4.166"
+      fill="none"
+    />
+    <path
+      d="m11.667 11.667.833-.834c.774-.744 1.726-.744 2.5 0l1.667 1.667"
+      fill="none"
+    />
+  </g>,
+  modifiedTablerIconProps,
+);
+
+// tabler-icons: eraser
+export const EraserIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M19 20h-10.5l-4.21 -4.3a1 1 0 0 1 0 -1.41l10 -10a1 1 0 0 1 1.41 0l5 5a1 1 0 0 1 0 1.41l-9.2 9.3" />
+    <path d="M18 13.3l-6.3 -6.3" />
+  </g>,
+  tablerIconProps,
+);
 
 // We inline font-awesome icons in order to save on js size rather than including the font awesome react library
 export const SHAPES = [
   {
-    icon: (
-      // fa-mouse-pointer
-      <svg viewBox="0 0 320 512" className="">
-        <path d="M302.189 329.126H196.105l55.831 135.993c3.889 9.428-.555 19.999-9.444 23.999l-49.165 21.427c-9.165 4-19.443-.571-23.332-9.714l-53.053-129.136-86.664 89.138C18.729 472.71 0 463.554 0 447.977V18.299C0 1.899 19.921-6.096 30.277 5.443l284.412 292.542c11.472 11.179 3.007 31.141-12.5 31.141z" />
-      </svg>
-    ),
+    icon: SelectionIcon,
     value: "selection",
     key: KEYS.V,
   },
   {
-    icon: (
-      // fa-square
-      <svg viewBox="0 0 448 512">
-        <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z" />
-      </svg>
-    ),
+    icon: RectangleIcon,
     value: "rectangle",
     key: KEYS.R,
   },
   {
-    icon: (
-      // custom
-      <svg viewBox="0 0 223.646 223.646">
-        <path d="M111.823 0L16.622 111.823 111.823 223.646 207.025 111.823z" />
-      </svg>
-    ),
+    icon: DiamondIcon,
     value: "diamond",
     key: KEYS.D,
   },
   {
-    icon: (
-      // fa-circle
-      <svg viewBox="0 0 512 512">
-        <path d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8z" />
-      </svg>
-    ),
+    icon: EllipseIcon,
     value: "ellipse",
     key: KEYS.O,
   },
   {
-    icon: (
-      // fa-long-arrow-alt-right
-      <svg viewBox="0 0 448 512" className="rtl-mirror">
-        <path d="M313.941 216H12c-6.627 0-12 5.373-12 12v56c0 6.627 5.373 12 12 12h301.941v46.059c0 21.382 25.851 32.09 40.971 16.971l86.059-86.059c9.373-9.373 9.373-24.569 0-33.941l-86.059-86.059c-15.119-15.119-40.971-4.411-40.971 16.971V216z" />
-      </svg>
-    ),
+    icon: ArrowIcon,
     value: "arrow",
     key: KEYS.A,
   },
   {
-    icon: (
-      // custom
-      <svg viewBox="0 0 6 6">
-        <line
-          x1="0"
-          y1="3"
-          x2="6"
-          y2="3"
-          stroke="currentColor"
-          strokeLinecap="round"
-        />
-      </svg>
-    ),
+    icon: LineIcon,
     value: "line",
     key: [KEYS.P, KEYS.L],
   },
   {
-    icon: (
-      // fa-pencil
-      <svg viewBox="0 0 512 512">
-        <path
-          fill="currentColor"
-          d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
-        ></path>
-      </svg>
-    ),
+    icon: FreedrawIcon,
     value: "freedraw",
     key: [KEYS.X, KEYS.P.toUpperCase()],
   },
   {
-    icon: (
-      // fa-font
-      <svg viewBox="0 0 448 512">
-        <path d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z" />
-      </svg>
-    ),
+    icon: TextIcon,
     value: "text",
     key: KEYS.T,
   },
   {
-    icon: (
-      // fa-image
-      <svg viewBox="0 0 512 512">
-        <path
-          fill="currentColor"
-          d="M464 64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V112c0-26.51-21.49-48-48-48zm-6 336H54a6 6 0 0 1-6-6V118a6 6 0 0 1 6-6h404a6 6 0 0 1 6 6v276a6 6 0 0 1-6 6zM128 152c-22.091 0-40 17.909-40 40s17.909 40 40 40 40-17.909 40-40-17.909-40-40-40zM96 352h320v-80l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L192 304l-39.515-39.515c-4.686-4.686-12.284-4.686-16.971 0L96 304v48z"
-        ></path>
-      </svg>
-    ),
+    icon: ImageIcon,
     value: "image",
     key: null,
   },


### PR DESCRIPTION
Now it's easier to add, manage, and reuse SVG assets efficiently

**Changes Made **
- Updated SVGs to match the latest design
- Created a reusable function to manage SVGs dynamically
- Simplified component structure by removing hardcoded SVGs

**Before :**

<img width="822" alt="Screenshot 2025-03-19 at 10 18 17 AM" src="https://github.com/user-attachments/assets/f0055411-9436-4637-9250-782ef2419b18" />


**After :**

<img width="912" alt="Screenshot 2025-03-19 at 10 17 50 AM" src="https://github.com/user-attachments/assets/d4a89a08-a2cf-43ae-9449-eb09ed8584f4" />



