### PR TITLE
feat: support async storage token provider for refreshable credentials

### DIFF
--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -490,7 +490,11 @@ class Collab extends PureComponent<CollabProps, CollabState> {
     // Initializing storage backend if storageBackendUrl & jwt are provided
     const { storageBackendUrl , meetingDetails } = this.props;
     // Session Id is required to initialize the storage backend
-    if (storageBackendUrl && meetingDetails?.sessionId && meetingDetails.token) {
+    if (
+      storageBackendUrl &&
+      meetingDetails?.sessionId &&
+      (meetingDetails.token || meetingDetails.getStorageToken)
+    ) {
       try {
         initializeBackend(storageBackendUrl, meetingDetails);
       } catch (error: any) {

--- a/excalidraw-app/data/storage.ts
+++ b/excalidraw-app/data/storage.ts
@@ -60,7 +60,17 @@ const _getBackendApi = () => {
   return backendApi;
 };
 
-const _getToken = () => {
+const _getToken = async (): Promise<string | undefined> => {
+  // A provider, when supplied, returns a fresh (possibly short-lived) token on
+  // every call and takes precedence over the static token.
+  if (meetingDetailsCache?.getStorageToken) {
+    try {
+      return await meetingDetailsCache.getStorageToken();
+    } catch (error) {
+      console.error("Failed to fetch storage token:", error);
+      return meetingDetailsCache?.token;
+    }
+  }
   return meetingDetailsCache?.token;
 };
 
@@ -82,7 +92,7 @@ const apiCall = async (endpoint: string, options: RequestInit = {}) => {
     ...options.headers as Record<string, string>,
   };
   
-  const token = _getToken();
+  const token = await _getToken();
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
   }
@@ -135,7 +145,7 @@ const uploadFilesWithMulter = async (prefix: string, files: { id: FileId; buffer
       formData.append('file', blob, id);
 
       const headers: Record<string, string> = {};
-      const token = _getToken();
+      const token = await _getToken();
       if (token) {
         headers['Authorization'] = `Bearer ${token}`;
       }
@@ -191,7 +201,7 @@ const downloadFilesFromBackend = async (prefix: string, fileIds: readonly FileId
   const erroredFiles: FileId[] = [];
 
   const headers: Record<string, string> = {};
-  const token = _getToken();
+  const token = await _getToken();
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
   }

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -611,6 +611,12 @@ export interface IMeetingDetails {
   jwt: string;
   jid: string;
   token?: string;
+  /**
+   * Optional async provider returning a fresh bearer token for each storage
+   * request. Takes precedence over the static `token` and lets the embedder
+   * supply short-lived credentials that are refreshed transparently.
+   */
+  getStorageToken?: () => Promise<string | undefined>;
 }
 
 export type SceneData = {


### PR DESCRIPTION
Add an optional `getStorageToken` callback to `IMeetingDetails`. When supplied, the storage layer awaits it for a fresh bearer token on every file upload/download request instead of reading the single static `token` captured at init. This lets embedders pass short-lived credentials that are refreshed transparently. Falls back to the static `token` when no provider is given, so existing integrations are unaffected.